### PR TITLE
Add Next.js expense tracker skeleton

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ children, ...props }, ref) => (
+    <button
+      ref={ref}
+      className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+      {...props}
+    >
+      {children}
+    </button>
+  )
+);
+Button.displayName = 'Button';

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (props, ref) => (
+    <textarea
+      ref={ref}
+      className="border rounded w-full p-2"
+      {...props}
+    />
+  )
+);
+Textarea.displayName = 'Textarea';

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "codexexperiments",
+  "version": "1.0.0",
+  "description": "Expense tracker using Next.js and Shadcn",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "openai": "4.44.1"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/api/tag.ts
+++ b/pages/api/tag.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import OpenAI from 'openai';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+
+  const { email } = req.body;
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+
+  try {
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [
+        { role: 'system', content: 'Decide if the following email describes a business expense. Respond only with "yes" or "no".' },
+        { role: 'user', content: email }
+      ]
+    });
+
+    const content = completion.choices[0].message.content || '';
+    const business = content.toLowerCase().includes('yes');
+    res.status(200).json({ business });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to call OpenAI' });
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { Button } from '../components/ui/button';
+import { Textarea } from '../components/ui/textarea';
+
+export default function Home() {
+  const [email, setEmail] = useState('');
+  const [business, setBusiness] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async () => {
+    setLoading(true);
+    const res = await fetch('/api/tag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    });
+    const data = await res.json();
+    setBusiness(data.business);
+    setLoading(false);
+  };
+
+  return (
+    <main className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Expense Tracker</h1>
+      <Textarea
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="Paste email text here"
+        rows={10}
+      />
+      <div className="mt-2">
+        <Button onClick={submit} disabled={loading}>
+          {loading ? 'Checking...' : 'Check'}
+        </Button>
+      </div>
+      {business !== null && (
+        <p className="mt-4 font-semibold">
+          {business ? 'Potential business expense' : 'Not a business expense'}
+        </p>
+      )}
+    </main>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,9 @@
+body {
+  font-family: sans-serif;
+  padding: 0;
+  margin: 0;
+}
+
+button {
+  cursor: pointer;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup basic Next.js project structure
- add simple Shadcn-style Button and Textarea components
- add page with form to check emails for business expenses using GPT-4o
- implement API route that queries OpenAI and returns result

## Testing
- `npm run build` *(fails: next not found)*